### PR TITLE
Update BitfinexSymbolInfo.cs

### DIFF
--- a/Bitfinex.Net/Objects/Models/BitfinexSymbolInfo.cs
+++ b/Bitfinex.Net/Objects/Models/BitfinexSymbolInfo.cs
@@ -10,6 +10,11 @@ namespace Bitfinex.Net.Objects.Models
     public class BitfinexSymbolInfo
     {
         /// <summary>
+        /// Maximum number of significant digits for price in this pair
+        /// </summary>
+        [ArrayProperty(1)]
+        public int PricePrecision { get; set; }
+        /// <summary>
         /// Min order quantity
         /// </summary>
         [ArrayProperty(3)]


### PR DESCRIPTION
PricePrecision is required to calculate prices

https://docs.bitfinex.com/v1/reference/rest-public-symbol-details

{
    "pair": "btcusd",
    "price_precision": 5,
    "initial_margin": "10.0",
    "minimum_margin": "5.0",
    "maximum_order_size": "2000.0",
    "minimum_order_size": "0.00006",
    "expiration": "NA",
    "margin": true
  },