### PR TITLE
Allow subscribing to the same feed more than once

### DIFF
--- a/Bitfinex.Net.UnitTests/SocketSubscriptionTests.cs
+++ b/Bitfinex.Net.UnitTests/SocketSubscriptionTests.cs
@@ -50,5 +50,17 @@ namespace Bitfinex.Net.UnitTests
             await tester.ValidateAsync<BitfinexMarginBase>((client, handler) => client.SpotApi.SubscribeToUserUpdatesAsync(marginBaseHandler: handler), "MarginBase");
             await tester.ValidateAsync<BitfinexMarginSymbol>((client, handler) => client.SpotApi.SubscribeToUserUpdatesAsync(marginSymbolHandler: handler), "MarginSymbol");
         }
+
+        [Test]
+        public async Task TestDoubleSubscription()
+        {
+            var client = new BitfinexSocketClient();
+            
+            var sub1 = await client.SpotApi.SubscribeToTickerUpdatesAsync("tETHUST", (data) => { });
+            var sub2 = await client.SpotApi.SubscribeToTickerUpdatesAsync("tETHUST", (data) => { });
+
+            Assert.That(sub1.Success);
+            Assert.That(sub2.Success);
+        }
     }
 }

--- a/Bitfinex.Net/Objects/Sockets/Queries/BitfinexSubQuery.cs
+++ b/Bitfinex.Net/Objects/Sockets/Queries/BitfinexSubQuery.cs
@@ -3,7 +3,6 @@ using CryptoExchange.Net.Objects.Sockets;
 using CryptoExchange.Net.Sockets;
 using System;
 using System.Collections.Generic;
-using System.Threading.Tasks;
 
 namespace Bitfinex.Net.Objects.Sockets.Queries
 {
@@ -35,7 +34,11 @@ namespace Bitfinex.Net.Objects.Sockets.Queries
         public override CallResult<BitfinexResponse> HandleMessage(SocketConnection connection, DataEvent<BitfinexResponse> message)
         {
             if (string.Equals(message.Data.Event, "error", StringComparison.Ordinal))
-                return new CallResult<BitfinexResponse>(new ServerError(message.Data.Message!));
+            {
+                // Additional check for "dup" which means the subscription is already active
+                if (!message.Data.Message.Equals("subscribe: dup", StringComparison.Ordinal))
+                    return new CallResult<BitfinexResponse>(new ServerError(message.Data.Message!));
+            }
 
             return new CallResult<BitfinexResponse>(message.Data);
         }


### PR DESCRIPTION
When subscribing to a feed already active on the connection, Bitfinex returns an error with "subscribe: dup".
This change will complete a subscription query because Bitfinex acknowledges this feed is active.

![image](https://github.com/JKorf/Bitfinex.Net/assets/10881387/54a464e4-0357-408b-a4ed-9941e351f61e)