### PR TITLE
Add travel rule parameters to withdrawal functionality

### DIFF
--- a/Bitfinex.Net/Clients/SpotApi/BitfinexRestClientSpotApiAccount.cs
+++ b/Bitfinex.Net/Clients/SpotApi/BitfinexRestClientSpotApiAccount.cs
@@ -223,6 +223,13 @@ namespace Bitfinex.Net.Clients.SpotApi
                                                                          string? intermediaryBankSwift = null,
                                                                          string? accountName = null,
                                                                          string? paymentId = null,
+                                                                         bool? travelRuleTos = null,
+                                                                         string? vaspDid = null,
+                                                                         string? vaspName = null,
+                                                                         bool? beneficiarySelf = null,
+                                                                         string? destFirstname = null,
+                                                                         string? destLastname = null,
+                                                                         string? destCorpName = null,
                                                                          CancellationToken ct = default)
         {
             withdrawType.ValidateNotNull(nameof(withdrawType));
@@ -242,13 +249,22 @@ namespace Bitfinex.Net.Clients.SpotApi
             parameters.AddOptionalParameter("bank_city", bankCity);
             parameters.AddOptionalParameter("bank_country", bankCountry);
             parameters.AddOptionalParameter("detail_payment", paymentDetails);
-            parameters.AddOptionalParameter("expressWire", expressWire == null ? null : expressWire == true ? "1": "0");
+            parameters.AddOptionalParameter("expressWire", expressWire == null ? null : expressWire == true ? "1" : "0");
             parameters.AddOptionalParameter("intermediary_bank_name", intermediaryBankName);
             parameters.AddOptionalParameter("intermediary_bank_address", intermediaryBankAddress);
             parameters.AddOptionalParameter("intermediary_bank_city", intermediaryBankCity);
             parameters.AddOptionalParameter("intermediary_bank_country", intermediaryBankCountry);
             parameters.AddOptionalParameter("intermediary_bank_account", intermediaryBankAccount);
             parameters.AddOptionalParameter("intermediary_bank_swift", intermediaryBankSwift);
+
+            parameters.AddOptionalParameter("travel_rule_tos", travelRuleTos);
+            parameters.AddOptionalParameter("vasp_did", vaspDid);
+            parameters.AddOptionalParameter("vasp_name", vaspName);
+            parameters.AddOptionalParameter("beneficiary_self", beneficiarySelf);
+            parameters.AddOptionalParameter("dest_firstname", destFirstname);
+            parameters.AddOptionalParameter("dest_lastname", destLastname);
+            parameters.AddOptionalParameter("dest_corp_name", destCorpName);
+
 
             var request = _definitions.GetOrCreate(HttpMethod.Post, "v1/withdraw", BitfinexExchange.RateLimiter.Overal, 1, true);
             var result = await _baseClient.SendAsync<IEnumerable<BitfinexWithdrawalResult>>(request, parameters, ct).ConfigureAwait(false);
@@ -283,7 +299,7 @@ namespace Bitfinex.Net.Clients.SpotApi
             parameters.AddOptionalParameter("payment_id", paymentId);
             parameters.AddOptionalParameter("invoice", invoice);
             parameters.AddOptionalParameter("note", note);
-            parameters.AddOptionalParameter("fee_deduct", feeFromWithdrawalAmount == null ? null : feeFromWithdrawalAmount == true ? 1: 0);
+            parameters.AddOptionalParameter("fee_deduct", feeFromWithdrawalAmount == null ? null : feeFromWithdrawalAmount == true ? 1 : 0);
 
             var request = _definitions.GetOrCreate(HttpMethod.Post, "v2/auth/w/withdraw", BitfinexExchange.RateLimiter.Overal, 1, true);
             return await _baseClient.SendAsync<BitfinexWithdrawalResultV2>(request, parameters, ct).ConfigureAwait(false);

--- a/Bitfinex.Net/Interfaces/Clients/SpotApi/IBitfinexRestClientSpotApiAccount.cs
+++ b/Bitfinex.Net/Interfaces/Clients/SpotApi/IBitfinexRestClientSpotApiAccount.cs
@@ -185,6 +185,13 @@ namespace Bitfinex.Net.Interfaces.Clients.SpotApi
         /// <param name="intermediaryBankSwift">Intermediary bank SWIFT code</param>
         /// <param name="accountName">The name of the account</param>
         /// <param name="paymentId">Hex string for Monero transaction</param>
+        /// <param name="travelRuleTos">Flag to voluntarily send travel rule details for withdrawal</param>
+        /// <param name="vaspDid">Virtual asset provider identifier, optional info for travel rule purpose. DID values can be found on https://api-pub.bitfinex.com/v2/ext/vasps endpoint.</param>
+        /// <param name="vaspName">Virtual asset provider name, optional info for travel rule purpose, if self custody ignore the field</param>
+        /// <param name="beneficiarySelf">Set to 'true' to extract destination data from your KYC data. (If 'true', dest_firstname, dest_lastname, or dest_corp_name do not need to be supplied)</param>
+        /// <param name="destFirstname">Destination entity first name for travel rule purpose (mandatory if dest_lastname is supplied, not required if beneficiary_self = true)</param>
+        /// <param name="destLastname">Destination entity last name for travel rule purpose (mandatory if dest_firstname is supplied, not required if beneficiary_self = true)</param>
+        /// <param name="destCorpName">Destination entity corporate name for travel rule purpose. (use either dest_firstname + dest_lastname or dest_corp_name, not required if beneficiary_self = true)</param>
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
         Task<WebCallResult<BitfinexWithdrawalResult>> WithdrawAsync(string withdrawType,
@@ -207,6 +214,13 @@ namespace Bitfinex.Net.Interfaces.Clients.SpotApi
             string? intermediaryBankSwift = null,
             string? accountName = null,
             string? paymentId = null,
+            bool? travelRuleTos = null,
+            string? vaspDid = null,
+            string? vaspName = null,
+            bool? beneficiarySelf = null,
+            string? destFirstname = null,
+            string? destLastname = null,
+            string? destCorpName = null,
             CancellationToken ct = default);
 
         /// <summary>


### PR DESCRIPTION
This commit introduces several optional parameters for travel rule compliance in the Bitfinex API withdrawal process. New parameters include `travelRuleTos`, `vaspDid`, `vaspName`, `beneficiarySelf`, `destFirstname`, `destLastname`, and `destCorpName`. Minor formatting adjustments were also made for consistency across the implementation and interface files.

See: https://docs.bitfinex.com/docs/withdraw-requests-and-the-travel-rule

Also not sure if this repo is open to contributions, if not just ignore and ill use a fork.