### PR TITLE
Format perpetual (linear) exchange assets

### DIFF
--- a/Bitfinex.Net/BitfinexExchange.cs
+++ b/Bitfinex.Net/BitfinexExchange.cs
@@ -64,6 +64,12 @@ namespace Bitfinex.Net
             baseAsset = AssetAliases.CommonToExchangeName(baseAsset);
             quoteAsset = AssetAliases.CommonToExchangeName(quoteAsset);
 
+            if (tradingMode == TradingMode.PerpetualLinear)
+            {
+                baseAsset = $"{baseAsset}F0";
+                quoteAsset = $"{quoteAsset}F0";
+            }
+
             if (baseAsset.Length != 3)
                 return $"t{baseAsset.ToUpperInvariant()}:{quoteAsset.ToUpperInvariant()}";
 


### PR DESCRIPTION
Fixes https://github.com/JKorf/Bitfinex.Net/issues/178

Not sure if this covers all cases as I didn't find any info about inverted perpetual derivatives on Bitfinex. This fix covers only `TradingMode.PerpetualLinear` trading mode (in addition to `Spot` of course).