### PR TITLE
Fixed BitfinexRestMessageHandler error code parsing

### DIFF
--- a/Bitfinex.Net/Clients/MessageHandlers/BitfinexRestMessageHandler.cs
+++ b/Bitfinex.Net/Clients/MessageHandlers/BitfinexRestMessageHandler.cs
@@ -1,10 +1,10 @@
-﻿using CryptoExchange.Net.Converters.SystemTextJson.MessageHandlers;
-using CryptoExchange.Net.Objects;
-using CryptoExchange.Net.Objects.Errors;
-using System.IO;
+﻿using System.IO;
 using System.Net.Http.Headers;
 using System.Text.Json;
 using System.Threading.Tasks;
+using CryptoExchange.Net.Converters.SystemTextJson.MessageHandlers;
+using CryptoExchange.Net.Objects;
+using CryptoExchange.Net.Objects.Errors;
 
 namespace Bitfinex.Net.Clients.MessageHandlers
 {
@@ -30,9 +30,9 @@ namespace Bitfinex.Net.Clients.MessageHandlers
 
             if (document!.RootElement.ValueKind == JsonValueKind.Array)
             {
-                var code = document.RootElement[1].GetInt32();
+                var code = document.RootElement[1].ValueKind == JsonValueKind.Null ? string.Empty : document.RootElement[1].GetInt32().ToString();
                 var msg = document.RootElement[2].GetString();
-                return new ServerError(code.ToString(), _errorMapping.GetErrorInfo(code.ToString(), msg));
+                return new ServerError(code, _errorMapping.GetErrorInfo(code, msg));
             }
             else
             {

--- a/Bitfinex.Net/Clients/MessageHandlers/BitfinexRestMessageHandler.cs
+++ b/Bitfinex.Net/Clients/MessageHandlers/BitfinexRestMessageHandler.cs
@@ -1,10 +1,10 @@
-﻿using System.IO;
+﻿using CryptoExchange.Net.Converters.SystemTextJson.MessageHandlers;
+using CryptoExchange.Net.Objects;
+using CryptoExchange.Net.Objects.Errors;
+using System.IO;
 using System.Net.Http.Headers;
 using System.Text.Json;
 using System.Threading.Tasks;
-using CryptoExchange.Net.Converters.SystemTextJson.MessageHandlers;
-using CryptoExchange.Net.Objects;
-using CryptoExchange.Net.Objects.Errors;
 
 namespace Bitfinex.Net.Clients.MessageHandlers
 {


### PR DESCRIPTION
Fixed parsing the error code for some requests. Sometimes the error code can be null.

Example Response: 
```json
["error",null,"ERR_QUERY"]
```

Example Exception:
```log
12:46:55.030 | Error | Bitfinex.RestClient | Unhandled exception when parsing error response: The requested operation requires an element of type 'Number', but the target element has type 'Null'.
System.InvalidOperationException: The requested operation requires an element of type 'Number', but the target element has type 'Null'.
   at System.Text.Json.ThrowHelper.ThrowJsonElementWrongTypeException(JsonTokenType expectedType, JsonTokenType actualType)
   at [Bitfinex.Net](http://bitfinex.net/).Clients.MessageHandlers.BitfinexRestMessageHandler.ParseErrorResponse(Int32 httpStatusCode, HttpResponseHeaders responseHeaders, Stream responseStream) in /_/[Bitfinex.Net/Clients/MessageHandlers/BitfinexRestMessageHandler.cs:line](http://bitfinex.net/Clients/MessageHandlers/BitfinexRestMessageHandler.cs:line) 33
   at [CryptoExchange.Net](http://cryptoexchange.net/).Clients.RestApiClient.GetResponseAsync2[T](RequestDefinition requestDefinition, IRequest request, IRateLimitGate gate, CancellationToken cancellationToken) in /_/[CryptoExchange.Net/Clients/RestApiClient.cs:line](http://cryptoexchange.net/Clients/RestApiClient.cs:line) 529
```