### PR TITLE
Add travel rule parameters to v2 WithdrawV2Async

### DIFF
--- a/Bitfinex.Net/Clients/SpotApi/BitfinexRestClientSpotApiAccount.cs
+++ b/Bitfinex.Net/Clients/SpotApi/BitfinexRestClientSpotApiAccount.cs
@@ -286,6 +286,13 @@ namespace Bitfinex.Net.Clients.SpotApi
                                                                          string? paymentId = null,
                                                                          bool? feeFromWithdrawalAmount = null,
                                                                          string? note = null,
+                                                                         bool? travelRuleTos = null,
+                                                                         string? vaspDid = null,
+                                                                         string? vaspName = null,
+                                                                         bool? beneficiarySelf = null,
+                                                                         string? destFirstname = null,
+                                                                         string? destLastname = null,
+                                                                         string? destCorpName = null,
                                                                          CancellationToken ct = default)
         {
             method.ValidateNotNull(nameof(method));
@@ -300,6 +307,13 @@ namespace Bitfinex.Net.Clients.SpotApi
             parameters.AddOptionalParameter("invoice", invoice);
             parameters.AddOptionalParameter("note", note);
             parameters.AddOptionalParameter("fee_deduct", feeFromWithdrawalAmount == null ? null : feeFromWithdrawalAmount == true ? 1 : 0);
+            parameters.AddOptionalParameter("travel_rule_tos", travelRuleTos);
+            parameters.AddOptionalParameter("vasp_did", vaspDid);
+            parameters.AddOptionalParameter("vasp_name", vaspName);
+            parameters.AddOptionalParameter("beneficiary_self", beneficiarySelf);
+            parameters.AddOptionalParameter("dest_firstname", destFirstname);
+            parameters.AddOptionalParameter("dest_lastname", destLastname);
+            parameters.AddOptionalParameter("dest_corp_name", destCorpName);
 
             var request = _definitions.GetOrCreate(HttpMethod.Post, "v2/auth/w/withdraw", BitfinexExchange.RateLimiter.Overall, 1, true);
             return await _baseClient.SendAsync<BitfinexWithdrawalResultV2>(request, parameters, ct).ConfigureAwait(false);

--- a/Bitfinex.Net/Interfaces/Clients/SpotApi/IBitfinexRestClientSpotApiAccount.cs
+++ b/Bitfinex.Net/Interfaces/Clients/SpotApi/IBitfinexRestClientSpotApiAccount.cs
@@ -316,6 +316,13 @@ namespace Bitfinex.Net.Interfaces.Clients.SpotApi
         /// <param name="paymentId">["payment_id"] Payment id (tag/memo)</param>
         /// <param name="feeFromWithdrawalAmount">["fee_deduct"] When true the fee will be deducted from the withdrawal quantity</param>
         /// <param name="note">["note"] Note</param>
+        /// <param name="travelRuleTos">["travel_rule_tos"] Flag to voluntarily send travel rule details for withdrawal</param>
+        /// <param name="vaspDid">["vasp_did"] Virtual asset provider identifier, optional info for travel rule purpose. DID values can be found on https://api-pub.bitfinex.com/v2/ext/vasps endpoint.</param>
+        /// <param name="vaspName">["vasp_name"] Virtual asset provider name, optional info for travel rule purpose, if self custody ignore the field</param>
+        /// <param name="beneficiarySelf">["beneficiary_self"] Set to 'true' to extract destination data from your KYC data. (If 'true', dest_firstname, dest_lastname, or dest_corp_name do not need to be supplied)</param>
+        /// <param name="destFirstname">["dest_firstname"] Destination entity first name for travel rule purpose (mandatory if dest_lastname is supplied, not required if beneficiary_self = true)</param>
+        /// <param name="destLastname">["dest_lastname"] Destination entity last name for travel rule purpose (mandatory if dest_firstname is supplied, not required if beneficiary_self = true)</param>
+        /// <param name="destCorpName">["dest_corp_name"] Destination entity corporate name for travel rule purpose. (use either dest_firstname + dest_lastname or dest_corp_name, not required if beneficiary_self = true)</param>
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
         Task<WebCallResult<BitfinexWithdrawalResultV2>> WithdrawV2Async(string method,
@@ -326,6 +333,13 @@ namespace Bitfinex.Net.Interfaces.Clients.SpotApi
                                                                          string? paymentId = null,
                                                                          bool? feeFromWithdrawalAmount = null,
                                                                          string? note = null,
+                                                                         bool? travelRuleTos = null,
+                                                                         string? vaspDid = null,
+                                                                         string? vaspName = null,
+                                                                         bool? beneficiarySelf = null,
+                                                                         string? destFirstname = null,
+                                                                         string? destLastname = null,
+                                                                         string? destCorpName = null,
                                                                          CancellationToken ct = default);
         /// <summary>
         /// Get login history


### PR DESCRIPTION
﻿## Summary

The v2 withdraw endpoint (`POST /v2/auth/w/withdraw`) accepts travel rule fields per the [official docs](https://docs.bitfinex.com/reference/rest-auth-withdraw), and the v1 `WithdrawAsync` already exposes them, but `WithdrawV2Async` did not. This adds the same set of optional travel rule parameters to the v2 method for parity.

Bitfinex blocks withdrawals over ~1k without travel rule details, so these fields are required to use the v2 endpoint for larger withdrawals.

## Changes

Added the following optional parameters to `WithdrawV2Async` (interface + implementation), appended to the request `ParameterCollection` exactly as the v1 `WithdrawAsync` already does:

| Parameter | Request field |
|---|---|
| `travelRuleTos` | `travel_rule_tos` |
| `vaspDid` | `vasp_did` |
| `vaspName` | `vasp_name` |
| `beneficiarySelf` | `beneficiary_self` |
| `destFirstname` | `dest_firstname` |
| `destLastname` | `dest_lastname` |
| `destCorpName` | `dest_corp_name` |

All parameters are optional (`null` by default) and only sent when provided, so this is a non-breaking, additive change. Existing callers are unaffected.

## Testing

Builds clean across all target frameworks (netstandard2.0, net8.0, net9.0, net10.0), 0 warnings / 0 errors. The existing `WithdrawV2` request test is unaffected since the new parameters default to null.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
