### PR TITLE
Fix sequence number read for unhandled messages on the authenticated channel

### DIFF
--- a/Bitfinex.Net/Clients/ExchangeApi/BitfinexSocketClientExchangeApi.cs
+++ b/Bitfinex.Net/Clients/ExchangeApi/BitfinexSocketClientExchangeApi.cs
@@ -85,8 +85,23 @@ namespace Bitfinex.Net.Clients.ExchangeApi
             if (doc.RootElement.ValueKind != JsonValueKind.Array)
                 return false;
 
-            // Sequence number is in second to last field
-            var sequenceField = doc.RootElement.GetArrayLength() - 2;
+            int sequenceField;
+            if (doc.RootElement[0].GetInt32() == 0)
+            {
+                // Messages on the authenticated channel carry two sequence numbers:
+                // [0, TYPE, PAYLOAD, MESSAGE_SEQUENCE, ACCOUNT_SEQUENCE, TIMESTAMP]
+                // Only MESSAGE_SEQUENCE increases by one per message, so that's the one to track. The second to last
+                // field would be ACCOUNT_SEQUENCE, which only changes on account activity and is a much larger number.
+                // Heartbeats have no payload, so their sequence number is one position earlier: [0, "hb", SEQUENCE, TIMESTAMP]
+                var payloadKind = doc.RootElement[2].ValueKind;
+                sequenceField = payloadKind == JsonValueKind.Array || payloadKind == JsonValueKind.Object ? 3 : 2;
+            }
+            else
+            {
+                // Public channel messages have a single sequence number in the second to last field
+                sequenceField = doc.RootElement.GetArrayLength() - 2;
+            }
+
             try
             {
                 var sequenceValue = doc.RootElement[sequenceField].GetInt64();


### PR DESCRIPTION
## Problem

When an authenticated message arrives that no subscription handles, the socket reconnects even though nothing is wrong.

The most common way to hit this is a wallet transfer. Bitfinex sends an `n` notification for it, and `n` is only routed while a query is pending. If you place your orders over REST, no query is ever pending, so every transfer triggers a reconnect.

## Cause

`HandleUnhandledMessage` reads the sequence number from the second to last field. That is correct for public messages, but authenticated messages have two sequence numbers:

```
[0,"n",[...,"wallet_transfer",...],143,15214,1786327545418]
                                    |     |
                                    |     +-- account sequence, only changes on account activity
                                    +-------- message sequence, +1 on every message
```

The second to last field is the account sequence, so the connection records `15214` instead of `143`. The next message arrives with `144`, that looks like a gap, and the connection reconnects.

## What it looks like in the log

```
received [0,"n",[1786327545417,"wallet_transfer",null,null,null,null,"SUCCESS",
                 "100.0 Tether USDt transferred from Margin to Exchange"],143,15214,1786327545418]
Setting connection sequence number to 15214 for unhandled message
[Sckt 10] update not in sequence. Last recorded sequence number: 142, update sequence number: 15214. Reconnecting
received [0,"wu",["margin","UST",<balance>,0,null,null,null],144,15215,1786327545453]
[Sckt 10] update not in sequence. Last recorded sequence number: 15214, update sequence number: 144. Reconnecting
```

Two reconnects are requested. The second one interrupts the first while it is authenticating:

```
authentication failed on reconnected socket. Disconnecting and reconnecting
failed reconnect processing: Authentication failed: : Connection interrupted, reconnecting again
```

It recovers after a retry, but any updates sent during those few seconds are lost. Bitfinex resends `ps`, `ws` and `os` on reconnect but not trades, so a fill that happens in that window never arrives.

## Workaround that confirms the cause

Setting `EnforceSequenceNumbers = false` on the socket API client stops the problem completely. The wrong sequence number is still recorded, but nothing acts on it:

```
received [0,"n",[...,"wallet_transfer",...,"100.0 Tether USDt transferred from Margin to Exchange"],26,15225,...]
Setting connection sequence number to 15225 for unhandled message
received [0,"wu",["margin","UST",<balance>,0,null,null,null],27,15226,...]     <- stream continues
received [0,"wu",["exchange","UST",<balance>,0,null,null,null],28,15227,...]
received [0,"hb",29,...]
```

With that set, transfers no longer reconnect, and order and trade updates keep flowing normally afterwards. Confirmed on a live account with single market orders and a five chunk TWAP.

## Fix

Read the message sequence for messages on channel 0. Heartbeats have no payload, so their sequence sits one position earlier, which the payload kind check handles.

## How to reproduce

1. Subscribe with `SubscribeToUserUpdatesAsync`
2. Transfer any amount between wallets over REST
3. The connection reconnects

Tested against a live account: before the change every transfer reconnected, after it none did.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
