### PR TITLE
Add META field to BitfinexPosition

### DIFF
--- a/Bitfinex.Net.UnitTests/Endpoints/Spot/Trading/ClaimPosition.txt
+++ b/Bitfinex.Net.UnitTests/Endpoints/Spot/Trading/ClaimPosition.txt
@@ -26,7 +26,7 @@ true
     null, 
     0, 
     null, 
-    "{\"reason\": \"TRADE\", \"order_id\": 31089337681, \"liq_stage\": null, \"trade_price\": \"10119.0\", \"trade_amount\": \"-0.001\", \"user_id_oppo\": 183923, \"order_id_oppo\": 31089692490}" 
+    {"reason": "TRADE", "order_id": 31089337681, "liq_stage": null, "trade_price": "10119.0", "trade_amount": "-0.001", "user_id_oppo": 183923, "order_id_oppo": 31089692490}
   ], 
   null, 	
   "SUCCESS", 

--- a/Bitfinex.Net/Objects/Models/BitfinexPosition.cs
+++ b/Bitfinex.Net/Objects/Models/BitfinexPosition.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Generic;
 using Bitfinex.Net.Enums;
+using CryptoExchange.Net.Attributes;
 using CryptoExchange.Net.Converters;
 
 namespace Bitfinex.Net.Objects.Models
@@ -107,5 +109,12 @@ namespace Bitfinex.Net.Objects.Models
         /// </summary>
         [ArrayProperty(18)]
         public decimal? MinCollateral { get; set; }
+        /// <summary>
+        /// Additional meta information about the position. On the positions audit endpoint a force-liquidated
+        /// position is marked here (reason "LIQ"), distinguishing a liquidation from a regular close.
+        /// </summary>
+        [ArrayProperty(19)]
+        [JsonConversion]
+        public IDictionary<string, object>? Meta { get; set; }
     }
 }


### PR DESCRIPTION
The v2 position array carries a META object at index 19 which `BitfinexPosition` currently doesn't map.

On the positions audit endpoint (`POST /v2/auth/r/positions/audit`, `GetPositionsByIdAsync`) META is where a force-liquidated position is marked — Bitfinex support confirmed a liquidation carries reason `"LIQ"` there, and it is the only way to distinguish a forced liquidation from a regular position close through the API.

Observed live payload shapes:

```json
{"reason":"FUNDING_ACCR","swap_ccy":"UST","swap_amount":"-0.032"}
{"reason":"FUNDING_SETTLE","swap_ccy":"UST","swap_amount":0}
```

The property is typed `IDictionary<string, object>?`, which `BitfinexSourceGenerationContext` already registers — no context changes needed. It is nullable and simply absent on payloads that don't include the element.

One file changed: the property plus two `using` directives.