### PR TITLE
Fix NullReferenceException in the socket message identifier when element 1 is not a string

### DIFF
--- a/Bitfinex.Net/Clients/MessageHandlers/BitfinexSocketMessageIdentifier.cs
+++ b/Bitfinex.Net/Clients/MessageHandlers/BitfinexSocketMessageIdentifier.cs
@@ -29,12 +29,22 @@ namespace Bitfinex.Net.Clients.MessageHandlers
                 var nodeType1 = document.RootElement[1].ValueKind;
                 if (nodeType1 != JsonValueKind.Array)
                 {
-                    var nodeValue1 = document.RootElement[1].GetString();
-                    if (nodeValue1!.Equals("hb") || nodeValue1.Equals("cs"))
-                        return id + nodeValue1;
+                    // Element 1 is not always a string; a live message can carry a JSON null here, and
+                    // GetString() then returns null, so only genuine strings get the hb/cs test
+                    if (nodeType1 == JsonValueKind.String)
+                    {
+                        var nodeValue1 = document.RootElement[1].GetString();
+                        if (nodeValue1!.Equals("hb") || nodeValue1.Equals("cs"))
+                            return id + nodeValue1;
+                    }
 
-                    var nodeTypeData = document.RootElement[2][0].ValueKind;
-                    return nodeTypeData == JsonValueKind.Array ? id + "array" : id + "single";
+                    if (document.RootElement.GetArrayLength() > 2)
+                    {
+                        var nodeTypeData = document.RootElement[2][0].ValueKind;
+                        return nodeTypeData == JsonValueKind.Array ? id + "array" : id + "single";
+                    }
+
+                    return id + "single";
                 }
                 else
                 {


### PR DESCRIPTION
`BitfinexSocketMessageIdentifier.GetTypeIdentifier` assumes element 1 of a channel message is a string whenever it is not an array:

```csharp
var nodeValue1 = document.RootElement[1].GetString();
if (nodeValue1!.Equals("hb") || nodeValue1.Equals("cs"))
```

A live socket message arrived carrying a JSON `null` at element 1. `GetString()` returns `null` for a null element, the null-forgiving `!` suppressed the warning, and `nodeValue1!.Equals("hb")` threw `NullReferenceException`, dropping the message inside the message handler. (We build from source, which is the only reason the throw was visible; the raw payload was unfortunately not captured, but the value kind at element 1 was confirmed `Null` in the debugger.)

This change:
- only runs the `hb`/`cs` test when element 1 is a genuine string; a null or numeric element falls through to the data-element classification,
- guards the `document.RootElement[2][0]` access behind an array-length check, so a short `[chanId, null]`-shaped array classifies as `single` instead of throwing on the missing element.

All existing unit tests pass (93/93).
