### PR TITLE
Add REST UpdateOrderAsync for updating an order in place

### DIFF
--- a/Bitfinex.Net/Clients/ExchangeApi/BitfinexRestClientExchangeApiTrading.cs
+++ b/Bitfinex.Net/Clients/ExchangeApi/BitfinexRestClientExchangeApiTrading.cs
@@ -167,6 +167,34 @@ namespace Bitfinex.Net.Clients.ExchangeApi
 
 
         /// <inheritdoc />
+        public async Task<HttpResult<BitfinexWriteResultOrder>> UpdateOrderAsync(
+            long orderId,
+            decimal? price = null,
+            decimal? quantity = null,
+            decimal? delta = null,
+            decimal? priceAuxiliaryLimit = null,
+            decimal? priceTrailing = null,
+            OrderFlags? flags = null,
+            int? leverage = null,
+            CancellationToken ct = default)
+        {
+            var parameters = new Parameters(BitfinexExchange._parameterSerializationSettings);
+            parameters.Add("id", orderId);
+            parameters.Add("amount", quantity?.ToString(CultureInfo.InvariantCulture));
+            parameters.Add("delta", delta?.ToString(CultureInfo.InvariantCulture));
+            parameters.Add("price", price?.ToString(CultureInfo.InvariantCulture));
+            parameters.Add("price_aux_limit", priceAuxiliaryLimit?.ToString(CultureInfo.InvariantCulture));
+            parameters.Add("price_trailing", priceTrailing?.ToString(CultureInfo.InvariantCulture));
+            parameters.Add("flags", (int?)flags);
+            parameters.Add("lev", leverage);
+
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "/v2/auth/w/order/update", BitfinexExchange.RateLimiter.Overall, 1, true,
+                limitGuard: new SingleLimitGuard(90, TimeSpan.FromSeconds(60), RateLimitWindowType.Sliding));
+            var result = await _baseClient.SendAsync<BitfinexWriteResultOrder>(request, parameters, ct).ConfigureAwait(false);
+            return result;
+        }
+
+        /// <inheritdoc />
         public async Task<HttpResult<BitfinexWriteResultOrder>> CancelOrderAsync(long? orderId = null, long? clientOrderId = null, DateTime? clientOrderIdDate = null, CancellationToken ct = default)
         {
             if (orderId != null && clientOrderId != null)

--- a/Bitfinex.Net/Interfaces/Clients/SpotApi/IBitfinexRestClientExchangeApiTrading.cs
+++ b/Bitfinex.Net/Interfaces/Clients/SpotApi/IBitfinexRestClientExchangeApiTrading.cs
@@ -147,6 +147,37 @@ namespace Bitfinex.Net.Interfaces.Clients.ExchangeApi
             CancellationToken ct = default);
 
         /// <summary>
+        /// Update an existing order in place, keeping its order id. The order's price, quantity and the
+        /// auxiliary and trailing prices can each be changed; for a stop order the price is the trigger.
+        /// <para>
+        /// Docs:<br />
+        /// <a href="https://docs.bitfinex.com/reference/rest-auth-update-order" /><br />
+        /// Endpoint:<br />
+        /// POST /v2/auth/w/order/update
+        /// </para>
+        /// </summary>
+        /// <param name="orderId">["id"] The id of the order to update</param>
+        /// <param name="price">["price"] The new price of the order</param>
+        /// <param name="quantity">["amount"] The new quantity of the order, negative for a sell</param>
+        /// <param name="delta">["delta"] Change the quantity by this amount instead of setting it outright</param>
+        /// <param name="priceAuxiliaryLimit">["price_aux_limit"] The new auxiliary limit price</param>
+        /// <param name="priceTrailing">["price_trailing"] The new trailing price</param>
+        /// <param name="flags">["flags"] The new order flags</param>
+        /// <param name="leverage">["lev"] The new leverage, for derivatives</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns></returns>
+        Task<HttpResult<BitfinexWriteResultOrder>> UpdateOrderAsync(
+            long orderId,
+            decimal? price = null,
+            decimal? quantity = null,
+            decimal? delta = null,
+            decimal? priceAuxiliaryLimit = null,
+            decimal? priceTrailing = null,
+            OrderFlags? flags = null,
+            int? leverage = null,
+            CancellationToken ct = default);
+
+        /// <summary>
         /// Cancel a specific order
         /// <para>
         /// Docs:<br />


### PR DESCRIPTION
The order update is currently available on the socket client only, although Bitfinex serves it over REST at `POST /v2/auth/w/order/update`. Callers restricted to REST therefore have no way to change a resting order - they must cancel and re-place, which for a stop order leaves the position unprotected between the two calls, and mints a new order id that any stored reference has to be updated to follow.

**Adds** `UpdateOrderAsync` to `IBitfinexRestClientExchangeApiTrading` and its implementation, mirroring the socket signature (`orderId`, `price`, `quantity`, `delta`, `priceAuxiliaryLimit`, `priceTrailing`, `flags`) plus `leverage`, which the endpoint accepts. It returns `BitfinexWriteResultOrder` and uses the same rate-limit guard as the place and cancel calls.

**Verified against the live API**: updating a resting stop order's price moved its trigger, a follow-up read confirmed the new price with the order still active, the order id was preserved, and a subsequent cancel against that original id succeeded.